### PR TITLE
Set sample dir/file permissions

### DIFF
--- a/dashdb_rstudio/Dockerfile
+++ b/dashdb_rstudio/Dockerfile
@@ -28,5 +28,9 @@ RUN rm -rf /var/lib/apt/lists/ \
 
 ADD samples /home/rstudio/samples
 
+## Copy and call startup script
+COPY startup.sh /tmp/startup.sh
+CMD ["/bin/bash", "/tmp/startup.sh"]
+
 ## Add ssh deamon to startup sequence
 ##RUN cat /supervisor.conf >> /etc/supervisor/conf.d/supervisord.conf

--- a/dashdb_rstudio/startup.sh
+++ b/dashdb_rstudio/startup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+chown rstudio:rstudio -R /home/rstudio/samples
+/init


### PR DESCRIPTION
Introduced a startup script for setting the sample dir/file owner to rstudio (RUN chmod has no effect since /home/rstudio is a volume).
