### PR TITLE
Disable dockers build cache in tests

### DIFF
--- a/dashdblocal_notebooks/test/Makefile
+++ b/dashdblocal_notebooks/test/Makefile
@@ -51,8 +51,8 @@ start:
 	@echo -e '\n\n### Starting test container ###'
 	# cleanup old stuff
 	-docker rm -f $(CONTAINER_NAME)
-	# fix permissions if we are root
 	rm -rf output && mkdir -p output
+	# fix permissions if we are root
 	chmod -R a+rX .
 	# launch docker container
 	docker run -d -v `pwd`:/test --name=$(CONTAINER_NAME) $(CONTAINER_CFG) $(IMAGE_NAME)

--- a/dashdblocal_notebooks/test/Makefile
+++ b/dashdblocal_notebooks/test/Makefile
@@ -59,7 +59,7 @@ start:
 	# wait for the container to start, write container output to stderr so we can see it
 	@grep -m1 'The Jupyter Notebook is running' <(timeout 1m docker logs -f $(CONTAINER_NAME) 2>&1 | tee /dev/stderr)
 	@echo "Started notebook container $(CONTAINER_NAME)"
-	
+
 # start the test container using bundler sources from the current directory,
 # overriding the bundler code that was deployed at image build time
 # useful when you are working on the bundler code; start the test container this way
@@ -74,14 +74,14 @@ start_dev:
 	@grep -m1 'The Jupyter Notebook is running' <(timeout 1m docker logs -f $(CONTAINER_NAME) 2>&1 | tee /dev/stderr)
 	@echo "Started notebook container $(CONTAINER_NAME)"
 	docker exec $(CONTAINER_NAME) pip install -e /src/sparkapp_bundler
-	
+
 start_interactive:
 	@echo '\n\n### Starting interactive container for development environment ###'
 	# cleanup old stuff
 	-docker rm -f $(CONTAINER_NAME)
 	# launch docker container
 	docker run -it --rm --entrypoint=bash -v `pwd`:/test -v `pwd`/../src:/src --name=$(CONTAINER_NAME) $(CONTAINER_CFG) $(IMAGE_NAME)
-	
+
 # stop and remove the test container
 # Note: simply killing the container with rm -f will not shut down running kernels in Spark
 # also shut down the Spark cluster to make sure we have no orphaned kernels left over
@@ -105,18 +105,18 @@ test_container_logs:
 test_notebook_ui:
 	@echo -e '\n\n### Checking notebook UI in test container ###'
 	DASHDBHOST=$(DASHDBHOST) DASHDBUSER=$(DASHDBUSER) DASHDBPASS=$(DASHDBPASS) python2 test_notebook_ui.py
-	
+
 # run the sample notebooks, test the kernel
 test_notebooks:
 	@echo -e '\n\n### Checking kernel and sample notebook ###'
 	rm -rf output/notebooks && mkdir -p output/notebooks && chmod a+rwx output/notebooks
 	docker exec $(CONTAINER_NAME) /test/test_notebooks.sh
-	
+
 # get spark-submit script from the dashDB server
 get_launcher:
 	curl -k -v -o $(SUBMIT_SCRIPT) -u $(DASHDBUSER):$(DASHDBPASS) https://$(DASHDBHOST):8443/blushiftservices/userfiledownload.do?path=spark-submit.sh
 	chmod a+rx $(SUBMIT_SCRIPT)
-	
+
 # test the bundlers. need the downloaded spark-submit script in the PATH
 test_bundlers:
 	@echo -e '\n\n### Checking notebook bundlers ###'

--- a/dashdblocal_notebooks/test/Makefile
+++ b/dashdblocal_notebooks/test/Makefile
@@ -33,7 +33,7 @@ run-test: image
 
 image: Dockerfile.$(ARCH)
 	@echo -e '\n\n### Building docker image for $ARCH###'
-	docker build -t $(IMAGE_NAME) -f Dockerfile.$(ARCH) ..
+	docker build --no-cache -t $(IMAGE_NAME) -f Dockerfile.$(ARCH) ..
 
 
 # Default Dockerfile is for Intel, just copy

--- a/dashdblocal_notebooks/test/test_notebooks.sh
+++ b/dashdblocal_notebooks/test/test_notebooks.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-NBCONVERT_OPTIONS="--to=markdown --ExecutePreprocessor.enabled=True --Application.log_level=DEBUG"
+NBCONVERT_OPTIONS="--to=markdown --ExecutePreprocessor.enabled=True --ExecutePreprocessor.timeout=1800 --Application.log_level=DEBUG"
 WORKDIR=/test/output/notebooks
 
 # nvbconvert always writes to the same directory where the notebooks are located
@@ -22,5 +22,3 @@ for notebook in $WORKDIR/*.ipynb; do
     # Spark cluster after each converted notebook
     curl -k -u $DASHDBUSER:$DASHDBPASS -XPOST https://$DASHDBHOST:8443/dashdb-api/analytics/public/cluster/deallocate
 done
-
-


### PR DESCRIPTION
On the machine where this test is running regularly, the cache was
hiding the problem fixed by 58663b5.
Disable the cache so test cases fail immediately when there's a problem.

The other interesting commit here is b010be0.